### PR TITLE
Add Jest framework with slugify tests

### DIFF
--- a/README.md
+++ b/README.md
@@ -732,3 +732,8 @@
     </script>
 </body>
 </html>
+<!--\nTesting\n\nTo run the unit tests, install dependencies with `npm install` and run `npm test`.\n-->
+
+## Testing
+
+Install dependencies with `npm install` and run `npm test` to execute the test suite.

--- a/__tests__/slugify.test.js
+++ b/__tests__/slugify.test.js
@@ -1,0 +1,13 @@
+const slugify = require('../slugify');
+
+test('converts spaces to hyphens', () => {
+  expect(slugify('Hello World')).toBe('hello-world');
+});
+
+test('removes special characters', () => {
+  expect(slugify('Hello+World!')).toBe('hello-world');
+});
+
+test('converts subscript digits', () => {
+  expect(slugify('CO₂₃₄ test')).toBe('co-234-test');
+});

--- a/package.json
+++ b/package.json
@@ -1,0 +1,16 @@
+{
+  "name": "paramedic-app",
+  "version": "1.0.0",
+  "description": "Paramedic quick reference application",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.5.0"
+  }
+}

--- a/slugify.js
+++ b/slugify.js
@@ -1,0 +1,18 @@
+function slugify(text) {
+  if (!text) return '';
+  return text
+    .toString()
+    .toLowerCase()
+    .replace(/\s+/g, '-')
+    .replace(/[+/:(),&%#₃₄]/g, match => {
+      if (match === '₃') return '3';
+      if (match === '₄') return '4';
+      return '-';
+    })
+    .replace(/[^\w-]+/g, '')
+    .replace(/--+/g, '-')
+    .replace(/^-+/, '')
+    .replace(/-+$/, '');
+}
+
+module.exports = slugify;


### PR DESCRIPTION
## Summary
- add `package.json` with Jest test framework
- implement `slugify.js` and unit tests
- document test setup in README

## Testing
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_683dc8a09fe08329afc7578926669826