### PR TITLE
Add initial Jest setup and example test

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,5 @@
 <!DOCTYPE html>
+<!-- To run tests, execute `npm test`. -->
 <html lang="en">
 <head>
     <meta charset="UTF-8">

--- a/package.json
+++ b/package.json
@@ -1,0 +1,17 @@
+{
+  "name": "paramedic-app",
+  "version": "1.0.0",
+  "description": "Paramedic Quick Reference",
+  "main": "index.js",
+  "scripts": {
+    "test": "jest"
+  },
+  "keywords": [],
+  "author": "",
+  "license": "ISC",
+  "type": "commonjs",
+  "devDependencies": {
+    "jest": "^29.0.0",
+    "jsdom": "^22.0.0"
+  }
+}

--- a/tests/toggle-info.test.js
+++ b/tests/toggle-info.test.js
@@ -1,0 +1,23 @@
+const fs = require('fs');
+const { JSDOM } = require('jsdom');
+
+describe('toggle-info styling', () => {
+  let document;
+  beforeAll(() => {
+    const html = fs.readFileSync(require('path').join(__dirname, '..', 'README.md'), 'utf8');
+    const dom = new JSDOM(html);
+    document = dom.window.document;
+  });
+
+  test('has toggle-info elements', () => {
+    const els = document.querySelectorAll('.toggle-info');
+    expect(els.length).toBeGreaterThan(0);
+  });
+
+  test('stylesheet contains cursor-pointer rule for toggle-info', () => {
+    const styles = Array.from(document.querySelectorAll('style'))
+      .map(s => s.textContent)
+      .join('\n');
+    expect(/\.toggle-info\s*\{[^}]*cursor-pointer/.test(styles)).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary
- add package.json with Jest and jsdom dev dependencies
- include npm test instructions in README
- test `.toggle-info` style

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840dfe58b2c832997edaf9bc0555070