### PR TITLE
Refactor README to reuse slugify module

### DIFF
--- a/README.md
+++ b/README.md
@@ -278,6 +278,7 @@
         <footer class="text-center p-4 text-gray-500 text-sm mt-2">App Version 0.7</footer>
     </div>
 
+    <script src="slugify.js"></script>
     <script>
         // --- DOM Elements ---
         const searchInput = document.getElementById('searchInput');
@@ -328,16 +329,7 @@
 
 
         // --- Utility Function ---
-        function slugify(text) {
-            if (!text) return '';
-            return text.toString().toLowerCase()
-                .replace(/\s+/g, '-')
-                .replace(/[+/:(),&%#₃₄]/g, (match) => {
-                    if (match === '₃') return '3'; if (match === '₄') return '4'; return '-';
-                })
-                .replace(/[^\w-]+/g, '')
-                .replace(/--+/g, '-').replace(/^-+/, '').replace(/-+$/, '');
-        }
+        // slugify is loaded from slugify.js
 
         // --- Sidebar Logic ---
         function openSidebar() { patientSidebar.classList.add('open'); sidebarOverlay.classList.add('active'); }

--- a/slugify.js
+++ b/slugify.js
@@ -12,4 +12,9 @@ function slugify(text) {
     .replace(/^-+/, '')
     .replace(/-+$/, '');
 }
-module.exports = slugify;
+
+if (typeof module !== 'undefined' && module.exports) {
+  module.exports = slugify;
+} else if (typeof window !== 'undefined') {
+  window.slugify = slugify;
+}


### PR DESCRIPTION
## Summary
- load `slugify.js` in the HTML rather than redefining the function
- expose `slugify` globally so it works both in Node tests and the browser

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6840eb9edc8c8329a7709519a88aba1f