### PR TITLE
Add underline and hover styles to toggle-info

### DIFF
--- a/README.md
+++ b/README.md
@@ -139,7 +139,16 @@
             margin-left: 0.5rem; /* ml-2 */
         }
 
-        .toggle-info { color: #15803d; cursor: pointer; }
+        .toggle-info {
+            color: #15803d;
+            cursor: pointer;
+            text-decoration: underline;
+            text-decoration-color: #15803d;
+        }
+        .toggle-info:hover {
+            color: #065f46;
+            background-color: #d1fae5;
+        }
         .toggle-info .info-text { margin-left: 0.25rem; }
 
         /* Header Navigation Buttons */


### PR DESCRIPTION
## Summary
- underline `.toggle-info` text in green
- darken text and highlight background on hover

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841125f37dc8329b816d5ea63d46139