### PR TITLE
Add green underline styling for toggle info

### DIFF
--- a/README.md
+++ b/README.md
@@ -142,8 +142,9 @@
         .toggle-info {
             color: #15803d;
             cursor: pointer;
-            text-decoration: underline;
+            text-decoration-line: underline;
             text-decoration-color: #15803d;
+            text-underline-offset: 2px;
         }
         .toggle-info:hover {
             color: #065f46;


### PR DESCRIPTION
## Summary
- emphasize toggle-info links by adding green underlines

## Testing
- `npm test --silent` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6841d4f64b8083299fadbe4b1d298d22