### PR TITLE
Fix search input event listener

### DIFF
--- a/README.md
+++ b/README.md
@@ -725,7 +725,13 @@
 
 
             searchInput.addEventListener('input', () => handleSearch(true));
-            searchInput.addEventListener('keypress', function(event) { if (event.key === 'Enter') { event.preventDefault(); handleSearch(true); }});
+            // Use keydown to reliably capture Enter key presses across browsers
+            searchInput.addEventListener('keydown', function(event) {
+                if (event.key === 'Enter') {
+                    event.preventDefault();
+                    handleSearch(true);
+                }
+            });
             renderInitialView(true);
             updateNavButtonsState();
         });


### PR DESCRIPTION
## Summary
- switch search input's key listener from `keypress` to `keydown`

## Testing
- `bash -lc 'grep -n keydown -n README.md | head'`

------
https://chatgpt.com/codex/tasks/task_e_683dc8fd96b08329809e62e6835e2749