### PR TITLE
Enable CLI slugify for branch names

### DIFF
--- a/README.md
+++ b/README.md
@@ -340,6 +340,9 @@
 
         // --- Utility Function ---
         // slugify is loaded from slugify.js
+        // You can also generate branch names with this helper:
+        //   node slugify.js "Administrative & Legal Essentials"
+        // yields "administrative-legal-essentials"
 
         // --- Sidebar Logic ---
         function openSidebar() { patientSidebar.classList.add('open'); sidebarOverlay.classList.add('active'); }

--- a/slugify.js
+++ b/slugify.js
@@ -19,3 +19,9 @@ if (typeof module !== 'undefined' && module.exports) {
 if (typeof window !== 'undefined') {
   window.slugify = slugify;
 }
+
+// Allow CLI usage: `node slugify.js "Some Text"`
+if (require.main === module) {
+  const input = process.argv.slice(2).join(' ');
+  console.log(slugify(input));
+}


### PR DESCRIPTION
## Summary
- allow slugify.js to be run as a CLI utility
- show example of generating branch names with slugify in README

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68424d4c59c0832993124ba7cbf9c0c9