### PR TITLE
Fix slugify browser error

### DIFF
--- a/slugify.js
+++ b/slugify.js
@@ -21,7 +21,7 @@ if (typeof window !== 'undefined') {
 }
 
 // Allow CLI usage: `node slugify.js "Some Text"`
-if (require.main === module) {
+if (typeof require !== 'undefined' && require.main === module) {
   const input = process.argv.slice(2).join(' ');
   console.log(slugify(input));
 }


### PR DESCRIPTION
## Summary
- guard require.main check in slugify.js so the script doesn't throw in browsers

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844fc840c90832982cf317b1967cf63