### PR TITLE
Handle all Unicode subscript digits in slugify

### DIFF
--- a/slugify.js
+++ b/slugify.js
@@ -1,10 +1,22 @@
+const subscriptMap = {
+  '₀': '0',
+  '₁': '1',
+  '₂': '2',
+  '₃': '3',
+  '₄': '4',
+  '₅': '5',
+  '₆': '6',
+  '₇': '7',
+  '₈': '8',
+  '₉': '9',
+};
+
 function slugify(text) {
   if (!text) return '';
   return text.toString().toLowerCase()
     .replace(/\s+/g, '-')
-    .replace(/[+/:(),&%#₃₄]/g, (match) => {
-      if (match === '₃') return '3';
-      if (match === '₄') return '4';
+    .replace(/[+/:(),&%#\u2080-\u2089]/g, (match) => {
+      if (subscriptMap[match]) return subscriptMap[match];
       return '-';
     })
     .replace(/[^\w-]+/g, '')

--- a/tests/slugify.test.js
+++ b/tests/slugify.test.js
@@ -8,6 +8,7 @@ describe('slugify', () => {
 
   test('handles special punctuation and subscript numbers', () => {
     expect(slugify('NaHCO₃')).toBe('nahco3');
+    expect(slugify('H₂O')).toBe('h2o');
     expect(slugify('1+1=2')).toBe('1-12');
     expect(slugify('Sample text (test)')).toBe('sample-text-test');
   });


### PR DESCRIPTION
## Summary
- map Unicode subscript digits ₀–₉ to plain numbers
- use the mapping in `slugify` character replacements
- verify subscript 2 in tests

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6844ffc7a4b08329b30c4dbc4324b217