### PR TITLE
Fix mobile viewport height handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,15 +8,16 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
     <style>
+        :root { --vh: 1vh; }
         body {
             font-family: 'Inter', sans-serif;
             overscroll-behavior-y: contain; /* Prevents pull-to-refresh on mobile */
             display: flex;
             flex-direction: column;
-            min-height: 100vh;
+            min-height: calc(var(--vh, 1vh) * 100);
         }
         #patient-sidebar {
-            position: fixed; top: 0; left: 0; width: 300px; max-width: 80%; height: 100vh;
+            position: fixed; top: 0; left: 0; width: 300px; max-width: 80%; height: calc(var(--vh, 1vh) * 100);
             background-color: #f9fafb; /* gray-50 */ border-right: 1px solid #e5e7eb; /* gray-200 */
             padding: 1rem; overflow-y: auto; z-index: 100; transform: translateX(-100%);
             transition: transform 0.3s ease-in-out; box-shadow: 2px 0 10px rgba(0,0,0,0.1);
@@ -203,6 +204,14 @@
         ::-webkit-scrollbar-thumb { background: #cbd5e1; border-radius: 10px; }
         ::-webkit-scrollbar-thumb:hover { background: #94a3b8; }
     </style>
+<script>
+  function setVh() {
+    const vh=window.innerHeight*0.01;
+    document.documentElement.style.setProperty("--vh", `${vh}px`);
+  }
+  window.addEventListener("resize", setVh);
+  setVh();
+</script>
 </head>
 <body class="bg-gray-100">
 
@@ -281,7 +290,7 @@
         </header>
 
         <main class="container mx-auto p-4 flex-grow">
-            <div id="content-area" class="bg-white p-3 md:p-6 rounded-lg shadow-lg min-h-[calc(100vh-200px)]">
+            <div id="content-area" class="bg-white p-3 md:p-6 rounded-lg shadow-lg min-h-[calc(var(--vh,1vh)*100-200px)]">
                 <p class="text-gray-500 text-center">Loading categories...</p>
             </div>
         </main>


### PR DESCRIPTION
## Summary
- improve mobile layout by using custom `--vh` variable instead of 100vh
- dynamically set `--vh` via JavaScript

## Testing
- `npm install` *(fails: 403 Forbidden)*
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68457124c6a4832981b3932eeac43ec4