### PR TITLE
Fix pediatric warning apostrophe

### DIFF
--- a/README.md
+++ b/README.md
@@ -621,7 +621,7 @@
                 // Pediatric Rx Warning
                 if (patientData.age !== null && patientData.age < PEDIATRIC_AGE_THRESHOLD) {
                     const pedsRxText = (topic.details.pediatricRx || []).join('').toLowerCase();
-                    if (!topic.details.pediatricRx || pedsRxText.length === 0 || pedsRxText.includes("don’t give") || pedsRxText.includes("not approved")) {
+                    if (!topic.details.pediatricRx || pedsRxText.length === 0 || pedsRxText.includes("don't give") || pedsRxText.includes("not approved")) {
                         collectedWarnings.push({ type: 'orange', text: `<strong>PEDIATRIC NOTE:</strong> No specific pediatric dosage listed or not recommended for pediatric use. Patient age: ${patientData.age}. Consider alternative or consult.` });
                     }
                 }


### PR DESCRIPTION
## Summary
- fix apostrophe in pediatric warning check that could cause UTF‑8 issues

## Testing
- `node --check app.js`

------
https://chatgpt.com/codex/tasks/task_e_6845793f79388329b5d6d040aa5d214c