### PR TITLE
Fix slug ID mismatch

### DIFF
--- a/slugList.js
+++ b/slugList.js
@@ -1,7 +1,7 @@
 const slugIDs = [
   '10-calcium-chloride',
   '2-lidocaine-xylocaine',
-  '84-sodium-bicarbonate-nahco3',
+  '8-4-sodium-bicarbonate-nahco3',
   'a-fib-rvr-or-a-flutter-stable-symptomatic',
   'abbott-approved-abbreviations',
   'abbreviations-references',


### PR DESCRIPTION
## Summary
- correct sodium bicarbonate slug id in slugList.js

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6845794a41c08329838ec7a290642b4e