### PR TITLE
Fix accidental taps on mobile

### DIFF
--- a/index.html
+++ b/index.html
@@ -480,7 +480,6 @@ if (typeof window !== 'undefined') window.slugIDs = slugIDs;
                 handler(e);
             };
             element.addEventListener('click', activate);
-            element.addEventListener('touchend', activate, { passive: false });
             element.addEventListener('keypress', (e) => {
                 if (e.key === 'Enter' || e.key === ' ') {
                     activate(e);


### PR DESCRIPTION
## Summary
- stop listening for `touchend` events when handling taps

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_6848342c2abc8329a2bc1c77bfb63f47