### PR TITLE
Fix detail text spacing

### DIFF
--- a/index.html
+++ b/index.html
@@ -131,7 +131,7 @@
         .detail-list li + li { margin-top: 0.25rem; /* space-y-1 */ }
         .detail-text {
             color: #374151; /* gray-700 */
-            white-space: pre-line;
+            white-space: pre-wrap;
         }
         .med-concentration {
             font-size: 0.875rem; /* text-sm */


### PR DESCRIPTION
## Summary
- use `white-space: pre-wrap` for `.detail-text` so leading spaces render

## Testing
- `npm test` *(fails: Missing script 'test')*

------
https://chatgpt.com/codex/tasks/task_e_6849bf12b1ec83298ac02721df724aed