### PR TITLE
Implement age-specific dose strikeouts

### DIFF
--- a/index.html
+++ b/index.html
@@ -598,6 +598,22 @@ if (typeof window !== 'undefined') window.slugIDs = slugIDs;
                 if (currentTopicId && allDisplayableTopicsMap[currentTopicId]) {
                     renderDetailPage(currentTopicId, false, false);
                 }
+                // Strike out age-inappropriate dose sections in an open medication detail
+                if (patientData.age) {
+                    if (patientData.age >= PEDIATRIC_AGE_THRESHOLD) {
+                        // Patient is adult – strike out pediatric doses
+                        document.querySelectorAll('.pediatric-section .detail-section-title, .pediatric-section .detail-text, .pediatric-section .detail-list')
+                                .forEach(el => el.classList.add('strikethrough'));
+                    } else {
+                        // Patient is pediatric – strike out adult doses
+                        document.querySelectorAll('.adult-section .detail-section-title, .adult-section .detail-text, .adult-section .detail-list')
+                                .forEach(el => el.classList.add('strikethrough'));
+                    }
+                } else {
+                    // If age not specified, ensure no strikeouts
+                    document.querySelectorAll('.adult-section .strikethrough, .pediatric-section .strikethrough')
+                            .forEach(el => el.classList.remove('strikethrough'));
+                }
             }
         }
         ptInputs.forEach(input => { if (input) input.addEventListener('input', updatePatientData); });


### PR DESCRIPTION
## Summary
- strikethrough age-inappropriate dose sections whenever patient info updates

## Testing
- `npm test` *(fails: missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684a43a26cf08329ac263e174f9328ae