### PR TITLE
Add Indications filter field

### DIFF
--- a/index.html
+++ b/index.html
@@ -249,11 +249,11 @@
               <textarea id="pt-medications" class="sidebar-input" rows="2" placeholder="Type or select, comma separated..."></textarea>
               <div id="pt-medications-suggestions" class="autocomplete-suggestions hidden"></div>
           </div>
-          <div class="mt-3 autocomplete-container">
-              <label for="pt-indications" class="sidebar-label">Indications:</label>
-              <textarea id="pt-indications" class="sidebar-input" rows="2" placeholder="Type or select, comma separated..."></textarea>
-              <div id="pt-indications-suggestions" class="autocomplete-suggestions hidden"></div>
-          </div>
+        <div class="mt-3 autocomplete-container">
+          <label for="pt-indications" class="sidebar-label">Indications:</label>
+          <textarea id="pt-indications" class="sidebar-input" rows="2" placeholder="Type or select, comma separated..."></textarea>
+          <div id="pt-indications-suggestions" class="autocomplete-suggestions hidden"></div>
+        </div>
           <div class="mt-3 autocomplete-container">
               <label for="pt-symptoms" class="sidebar-label">Signs/Symptoms (S/S):</label>
               <textarea id="pt-symptoms" class="sidebar-input" rows="3" placeholder="Type or select, comma separated..."></textarea>
@@ -999,15 +999,6 @@ if (typeof window !== 'undefined') window.slugIDs = slugIDs;
                 <div class="bg-gray-50 p-4 rounded-lg shadow-inner space-y-3 text-gray-800">${detailContentHtml}</div>`;
             attachToggleInfoHandlers(contentArea);
             attachToggleCategoryHandlers(contentArea);
-            // After rendering medication detail content:
-            contentArea.querySelectorAll('.toggle-category').forEach(header => {
-                header.addEventListener('click', () => {
-                    const contentDiv = header.nextElementSibling;
-                    if (contentDiv) {
-                        contentDiv.classList.toggle('hidden');  // show/hide the content
-                    }
-                });
-            });
             addTapListener(document.getElementById('backToListButton'), () => { /* ... same as v0.6 ... */
                 for (let i = currentHistoryIndex -1 ; i >= 0; i--) {
                     if (navigationHistory[i] && navigationHistory[i].viewType === 'list') {


### PR DESCRIPTION
## Summary
- standardize HTML snippet for the Indications input field
- toggle medication detail sections in a single handler

## Testing
- `npm test` *(fails: Missing script)*

------
https://chatgpt.com/codex/tasks/task_e_684b290c259083299110935ca4607deb