### PR TITLE
Fix medication details lookup

### DIFF
--- a/Data/MedDetails.js
+++ b/Data/MedDetails.js
@@ -1,7 +1,12 @@
 function initializeData(categoriesData, medDetails) {
     // Ensure the data passed is valid, otherwise use empty arrays/objects.
     paramedicCategories = categoriesData || [];
-    const medicationData = medDetails || {};
+    // Allow medDetails to be provided as an array or an object
+    // If an array is given (the format used by MedicationDetailsData.js),
+    // convert it to an id -> object map for easier lookup.
+    const medicationData = Array.isArray(medDetails)
+        ? Object.fromEntries(medDetails.map(m => [m.id, m]))
+        : (medDetails || {});
 
     allSearchableTopics = [];
     allDisplayableTopicsMap = {};

--- a/Data/MedicationDetailsData.js
+++ b/Data/MedicationDetailsData.js
@@ -115,13 +115,7 @@ const MedicationDetailsData = [
         adultRx: ["Give D10 in 10g increments until BGL >100 mg/dL"]
     },
     {
-        _id: 'dexamethasone-decadron',
-        get id() {
-            return this._id;
-        },
-        set id(value) {
-            this._id = value;
-        },
+        id: 'dexamethasone-decadron',
         title: "Dexamethasone (Decadron)",
         concentration: "(10mg/ml)",
         class: "corticosteroid, anti-inflammatory",


### PR DESCRIPTION
## Summary
- convert medication details array into object map during initialization
- correct `id` field for dexamethasone entry

## Testing
- `npm test` *(fails: jest not found)*
- `npm test` from project root *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_685f02071180832984011465d98b850e