### PR TITLE
Fix navigation arrow history state

### DIFF
--- a/Features/PatientInfo.js
+++ b/Features/PatientInfo.js
@@ -19,9 +19,10 @@
         const ptInputs = ptInputIds.map(id => document.getElementById(id));
 
         // --- Navigation History ---
-        let navigationHistory = [];
-        let currentHistoryIndex = -1;
-        let isNavigatingViaHistory = false;
+        // Main navigation state is now defined in main.js so the header
+        // arrows work reliably.  These variables were left here previously
+        // but served no purpose, so they have been removed to avoid
+        // shadowing the globals.
 
         // --- Hierarchical Data, Flat Search List, Medication Details ---
 

--- a/main.js
+++ b/main.js
@@ -12,6 +12,16 @@ const sidebarOverlay    = document.getElementById('sidebar-overlay');
 let navBackButton     = document.getElementById('nav-back-button');
 let navForwardButton  = document.getElementById('nav-forward-button');
 
+// Navigation history state
+// These globals track the list of visited views so the header
+// back/forward buttons can navigate correctly. They were previously
+// only defined in PatientInfo.js which meant main.js could fail to
+// reference them if that script loaded differently.  Defining them
+// here guarantees the navigation arrows always function.
+let navigationHistory    = [];
+let currentHistoryIndex  = -1;
+let isNavigatingViaHistory = false;
+
 // --- Ensure Navigation/Search Bar Exists ---
 function ensureHeaderUI() {
   const header = document.querySelector('header');


### PR DESCRIPTION
## Summary
- declare navigation history variables in main.js so arrows always work
- remove outdated variables from Features/PatientInfo.js

## Testing
- `npm test` *(fails: package.json missing)*

------
https://chatgpt.com/codex/tasks/task_e_6860ab31c48883299f8dde57b8a870ff