### PR TITLE
Fix medication detail headers layout

### DIFF
--- a/main.js
+++ b/main.js
@@ -295,7 +295,7 @@ function createHierarchicalList(items, container, level = 0) {
             // Collapsible blue arrow
             const arrow = document.createElement('button');
             arrow.setAttribute('aria-label', 'Expand/collapse');
-            arrow.className = 'mr-2 focus:outline-none focus:ring-2 focus:ring-blue-400';
+            arrow.className = 'arrow mr-2 focus:outline-none focus:ring-2 focus:ring-blue-400';
             arrow.innerHTML = `<svg class="h-4 w-4 text-blue-600 transition-transform duration-200" style="transform: rotate(${item.expanded ? 90 : 0}deg);" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>`;
             addTapListener(arrow, () => {
                 item.expanded = !item.expanded;
@@ -451,7 +451,8 @@ function renderDetailPage(topicId, scrollToTop = true, shouldAddHistory = true) 
                 const header = document.createElement('div');
                 header.className = 'flex items-center cursor-pointer select-none toggle-category';
                 const arrow = document.createElement('span');
-                arrow.innerHTML = `<svg class="h-4 w-4 text-blue-600 transition-transform duration-200 mr-2" style="transform: rotate(0deg);" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>`;
+                arrow.className = 'arrow';
+                arrow.innerHTML = `<svg class="h-4 w-4 text-blue-600 transition-transform duration-200" style="transform: rotate(0deg);" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>`;
                 header.appendChild(arrow);
                 const label = document.createElement('span');
                 label.textContent = section.label;

--- a/styles.js
+++ b/styles.js
@@ -250,12 +250,12 @@ window.tailwind.config = {
         ".toggle-category": {
           cursor: "pointer",
           display: "flex",
-          justifyContent: "space-between",
+          justifyContent: "flex-start",
           alignItems: "center"
         },
         ".arrow": {
           transition: "transform 0.2s",
-          marginLeft: "0.25rem"
+          marginRight: "0.5rem"
         },
         ".arrow.rotate": {
           transform: "rotate(-180deg)"


### PR DESCRIPTION
## Summary
- adjust layout so detail headers show next to the collapsible arrow
- assign `arrow` class to navigation buttons for consistent styling

## Testing
- `npm test --silent` *(fails: ENOTFOUND registry.npmjs.org)*

------
https://chatgpt.com/codex/tasks/task_e_6860aaf5a4288329b9ea20092ce67c70