### PR TITLE
Fix medication detail section layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ All scripts are included in `index.html` in the proper order. Notably, the data 
   - The main topic title in detail view now uses a consistent class and data attribute for reliable UI updates.
   - The `ensureHeaderUI` function in `main.js` was patched to always create and order navigation/search elements correctly, fixing header UI consistency.
   - **Slug Anchors Initialization:** `slugAnchors.js` now waits for the DOM to load before inserting hidden anchor elements, ensuring the container is appended reliably.
+  - **Medication Detail Layout:** Section headers like *Indications* and *Precautions* now align directly beside the blue arrow instead of being spaced across the screen. This was fixed by updating the `.toggle-category` style to use `justify-content: flex-start`.
 
 - **Testing:**
   - All Jest tests now pass. The `add.test.js` import path was fixed, and a minimal test for `slugify.js` was added. The test suite is clean and ready for further test additions.

--- a/styles.js
+++ b/styles.js
@@ -250,7 +250,7 @@ window.tailwind.config = {
         ".toggle-category": {
           cursor: "pointer",
           display: "flex",
-          justifyContent: "space-between",
+          justifyContent: "flex-start",
           alignItems: "center"
         },
         ".arrow": {


### PR DESCRIPTION
## Summary
- style `.toggle-category` with `justify-content:flex-start` so headings like Indications display next to the arrow
- document medication detail layout fix in the README

## Testing
- `npm test` *(fails: jest not installed)*

------
https://chatgpt.com/codex/tasks/task_e_6860aaf5a4288329b9ea20092ce67c70