### PR TITLE
Implement detail page table of contents

### DIFF
--- a/README.md
+++ b/README.md
@@ -73,6 +73,7 @@ All scripts are included in `index.html` in the proper order. Notably, the data 
   - The main topic title in detail view now uses a consistent class and data attribute for reliable UI updates.
   - The `ensureHeaderUI` function in `main.js` was patched to always create and order navigation/search elements correctly, fixing header UI consistency.
   - **Slug Anchors Initialization:** `slugAnchors.js` now waits for the DOM to load before inserting hidden anchor elements, ensuring the container is appended reliably.
+  - **Detail Table of Contents:** Each medication detail page now shows a generated Table of Contents for its sections. `renderDetailPage` passes the section list to `setupSlugAnchors`, which builds the anchor list immediately on page load.
   - **Medication Detail Layout:** Section headers like *Indications* and *Precautions* now align directly beside the blue arrow instead of being spaced across the screen. This was fixed by updating the `.toggle-category` style to use `justify-content: flex-start`.
 
 - **Testing:**

--- a/main.js
+++ b/main.js
@@ -454,19 +454,25 @@ function renderDetailPage(topicId, scrollToTop = true, shouldAddHistory = true) 
             { key: 'adultRx', label: 'Adult Rx' },
             { key: 'pediatricRx', label: 'Pediatric Rx' }
         ];
+        const tocItems = [];
         sections.forEach(section => {
             if (d[section.key]) {
                 const wrapper = document.createElement('div');
-                wrapper.className = 'mb-2';
+                wrapper.className = 'detail-section mb-2';
+                const sectionId = typeof slugify === 'function' ? slugify(section.label) : section.label.toLowerCase().replace(/\s+/g, '-');
+                wrapper.id = sectionId;
+                wrapper.dataset.label = section.label;
+                tocItems.push({ label: section.label, id: sectionId });
+
                 const header = document.createElement('div');
                 header.className = 'flex items-center cursor-pointer select-none toggle-category';
                 const arrow = document.createElement('span');
                 arrow.className = 'arrow';
-                arrow.innerHTML = `<svg class="h-4 w-4 text-blue-600 transition-transform duration-200" style="transform: rotate(0deg);" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>`;
+                arrow.innerHTML = `<svg class="h-4 w-4 text-blue-600 transition-transform duration-200" style="transform: rotate(0deg);" fill="none" viewBox="0 0 24 24" stroke="currentColor"><path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M9 5l7 7-7 7" /></svg>`; 
                 header.appendChild(arrow);
-                const label = document.createElement('span');
-                label.textContent = section.label;
-                header.appendChild(label);
+                const labelEl = document.createElement('span');
+                labelEl.textContent = section.label;
+                header.appendChild(labelEl);
                 wrapper.appendChild(header);
                 const body = document.createElement('div');
                 body.className = 'pl-6 py-2 hidden';
@@ -485,6 +491,10 @@ function renderDetailPage(topicId, scrollToTop = true, shouldAddHistory = true) 
                 contentArea.appendChild(wrapper);
             }
         });
+
+        if (tocItems.length > 0 && typeof window.setupSlugAnchors === 'function') {
+            window.setupSlugAnchors(tocItems);
+        }
     } else {
         // Fallback: show description
         const desc = document.createElement('div');

--- a/slugAnchors.js
+++ b/slugAnchors.js
@@ -1,26 +1,64 @@
-// Generate hidden anchor container for slug IDs
-// Allows linking or branch automation based on slug IDs
-if (typeof document !== 'undefined') {
-  const setupSlugAnchors = () => {
-    if (typeof slugIDs === 'undefined' || !Array.isArray(slugIDs)) return;
-    const container = document.createElement('div');
-    container.id = 'slug-id-container';
-    container.classList.add('hidden');
-    slugIDs.forEach(id => {
-      const div = document.createElement('div');
-      div.id = id;
-      div.dataset.branch = id;
-      container.appendChild(div);
+// Setup or update the table of contents for detail sections
+// Also inject hidden anchor elements for branch automation
+function setupSlugAnchors(tocData) {
+  if (typeof document === 'undefined') return;
+
+  // Hidden container of slug IDs for external automation
+  if (typeof slugIDs !== 'undefined' && Array.isArray(slugIDs)) {
+    if (!document.getElementById('slug-id-container')) {
+      const container = document.createElement('div');
+      container.id = 'slug-id-container';
+      container.classList.add('hidden');
+      slugIDs.forEach(id => {
+        const div = document.createElement('div');
+        div.id = id;
+        div.dataset.branch = id;
+        container.appendChild(div);
+      });
+      document.body.appendChild(container);
+    }
+  }
+
+  if (Array.isArray(tocData) && tocData.length > 0) {
+    const contentArea = document.getElementById('content-area');
+    if (!contentArea) return;
+    const existing = document.getElementById('detail-toc');
+    if (existing) existing.remove();
+
+    const nav = document.createElement('nav');
+    nav.id = 'detail-toc';
+    nav.className = 'mb-4';
+    const heading = document.createElement('h3');
+    heading.className = 'font-semibold mb-1';
+    heading.textContent = 'Table of Contents';
+    nav.appendChild(heading);
+    const list = document.createElement('ul');
+    list.className = 'list-disc ml-6 space-y-1';
+    tocData.forEach(item => {
+      const li = document.createElement('li');
+      const a = document.createElement('a');
+      a.href = `#${item.id}`;
+      a.textContent = item.label;
+      a.className = 'text-blue-600 hover:underline';
+      li.appendChild(a);
+      list.appendChild(li);
     });
-    document.body.appendChild(container);
-  };
+    nav.appendChild(list);
+    const insertPoint = contentArea.children[1] || null;
+    contentArea.insertBefore(nav, insertPoint);
+  }
+}
+
+if (typeof document !== 'undefined') {
   if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', setupSlugAnchors);
+    document.addEventListener('DOMContentLoaded', () => setupSlugAnchors());
   } else {
     setupSlugAnchors();
   }
 }
 
 if (typeof module !== 'undefined') {
-  module.exports = {};
+  module.exports = { setupSlugAnchors };
+} else if (typeof window !== 'undefined') {
+  window.setupSlugAnchors = setupSlugAnchors;
 }


### PR DESCRIPTION
## Summary
- generate section IDs and pass them to `setupSlugAnchors` when rendering a detail page
- build table of contents in `slugAnchors.js`
- document table of contents behavior in README

## Testing
- `npm --prefix dev-tools test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860c6b42b38832998bf0df5ec8cd75f