### PR TITLE
Add IE compatibility meta tag and polyfill

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,8 @@
 <head>
     <meta charset="UTF-8">
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <meta http-equiv="X-UA-Compatible" content="IE=edge">
+    <script src="https://polyfill.io/v3/polyfill.min.js?features=default%2CArray.prototype.forEach%2CPromise%2CObject.assign%2CArray.prototype.includes"></script>
     <title>Paramedic Quick Reference</title>
 
     <!-- Load Tailwind configuration before the CDN script so the settings take effect -->


### PR DESCRIPTION
## Summary
- add `X-UA-Compatible` meta tag
- load polyfills for older browser support in `index.html`

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_6860ec65a54c832995cbc368474431a6