### PR TITLE
Fix ampersand in Google Fonts link

### DIFF
--- a/index.html
+++ b/index.html
@@ -18,7 +18,7 @@
     <script src="https://cdn.tailwindcss.com"></script>
     <script defer src="viewportFix.js" ></script>
     
-    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&display=swap" rel="stylesheet">
+    <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&amp;display=swap" rel="stylesheet">
 </head>
 <body class="bg-gray-100">
 <h1 class="text-lg sm:text-xl md:text-2xl font-semibold text-center flex-grow px-2">Paramedic Quick Reference</h1>


### PR DESCRIPTION
## Summary
- fix HTML syntax issue by escaping ampersand in the Google Fonts link

## Testing
- `npm test` *(fails: jest not found)*

------
https://chatgpt.com/codex/tasks/task_e_68610bdc9568832999a0ce9a62076c77