### PR TITLE
Fix stored DOM XSS in patient autocomplete suggestions

### DIFF
--- a/Features/patient/Autocomplete.js
+++ b/Features/patient/Autocomplete.js
@@ -10,12 +10,32 @@ export function setupAutocomplete(textareaId, suggestionsContainerId, suggestion
   const normalizedField = (fieldKey || '').toLowerCase();
   const baseValues = suggestionSourceSet ? Array.from(suggestionSourceSet) : [];
 
+  const clearSuggestions = () => {
+    suggestionsContainer.replaceChildren();
+  };
+
+  const hideSuggestions = () => {
+    suggestionsContainer.classList.add('hidden');
+    clearSuggestions();
+  };
+
+  const renderRows = rows => {
+    const nodes = rows.map(entry => {
+      const item = document.createElement('div');
+      item.className = 'autocomplete-suggestion-item';
+      item.dataset.canonical = entry.canonical;
+      item.dataset.display = entry.display;
+      item.textContent = entry.display;
+      return item;
+    });
+    suggestionsContainer.replaceChildren(...nodes);
+  };
+
   const renderSuggestions = () => {
     const { committed, current } = splitSegments(textarea.value);
     const currentLower = current.toLowerCase();
     if (currentLower.length === 0) {
-      suggestionsContainer.classList.add('hidden');
-      suggestionsContainer.innerHTML = '';
+      hideSuggestions();
       return;
     }
     const committedCanonical = new Set(
@@ -36,13 +56,10 @@ export function setupAutocomplete(textareaId, suggestionsContainerId, suggestion
       seenCanonicals.add(canonicalLower);
     });
     if (rows.length === 0) {
-      suggestionsContainer.classList.add('hidden');
-      suggestionsContainer.innerHTML = '';
+      hideSuggestions();
       return;
     }
-    suggestionsContainer.innerHTML = rows.map(entry => (
-      `<div class="autocomplete-suggestion-item" data-canonical="${entry.canonical}" data-display="${entry.display}">${entry.display}</div>`
-    )).join('');
+    renderRows(rows);
     suggestionsContainer.classList.remove('hidden');
   };
 
@@ -58,8 +75,7 @@ export function setupAutocomplete(textareaId, suggestionsContainerId, suggestion
       nextValues.push(displayValue);
     }
     textarea.value = nextValues.join(', ') + (nextValues.length ? ', ' : '');
-    suggestionsContainer.classList.add('hidden');
-    suggestionsContainer.innerHTML = '';
+    hideSuggestions();
     textarea.focus();
     textarea.dispatchEvent(new Event('input'));
   });
@@ -78,22 +94,38 @@ export function setupSingleValueAutocomplete(inputId, suggestionsContainerId, su
 
   const baseValues = suggestionSourceSet ? Array.from(suggestionSourceSet) : [];
 
+  const clearSuggestions = () => {
+    suggestionsContainer.replaceChildren();
+  };
+
+  const hideSuggestions = () => {
+    suggestionsContainer.classList.add('hidden');
+    clearSuggestions();
+  };
+
+  const renderRows = rows => {
+    const nodes = rows.map(option => {
+      const item = document.createElement('div');
+      item.className = 'autocomplete-suggestion-item';
+      item.dataset.value = option;
+      item.textContent = option;
+      return item;
+    });
+    suggestionsContainer.replaceChildren(...nodes);
+  };
+
   const renderSuggestions = () => {
     const current = (input.value || '').trim().toLowerCase();
     if (!current) {
-      suggestionsContainer.classList.add('hidden');
-      suggestionsContainer.innerHTML = '';
+      hideSuggestions();
       return;
     }
     const rows = baseValues.filter(option => option.toLowerCase().includes(current));
     if (!rows.length) {
-      suggestionsContainer.classList.add('hidden');
-      suggestionsContainer.innerHTML = '';
+      hideSuggestions();
       return;
     }
-    suggestionsContainer.innerHTML = rows.map(option => (
-      `<div class="autocomplete-suggestion-item" data-value="${option}">${option}</div>`
-    )).join('');
+    renderRows(rows);
     suggestionsContainer.classList.remove('hidden');
   };
 
@@ -104,8 +136,7 @@ export function setupSingleValueAutocomplete(inputId, suggestionsContainerId, su
     if (!item) return;
     const value = item.dataset.value || '';
     input.value = value;
-    suggestionsContainer.classList.add('hidden');
-    suggestionsContainer.innerHTML = '';
+    hideSuggestions();
     input.focus();
     input.dispatchEvent(new Event('input'));
   });


### PR DESCRIPTION
### Motivation
- Learned patient terms were persisted to `localStorage` and later injected into the autocomplete suggestion markup using `innerHTML`, creating a stored DOM XSS sink. 
- The change aims to remove the XSS sink with a minimal, behavior-preserving fix by rendering suggestions safely.

### Description
- Replaced `innerHTML`-based suggestion rendering in `Features/patient/Autocomplete.js` with safe DOM construction using `document.createElement` and `textContent` so suggestion text cannot be interpreted as HTML. 
- Added `clearSuggestions`, `hideSuggestions`, and `renderRows` helpers to consistently clear/hide the suggestions container without HTML string interpolation. 
- Applied the safe rendering approach to both the multi-value (`setupAutocomplete`) and single-value (`setupSingleValueAutocomplete`) flows while preserving `data-*` attributes consumed by tap handlers.

### Testing
- Ran `npm run lint:js` which completed with warnings only and no errors, indicating the change does not introduce linting errors. 
- Performed a static review of `Features/patient/Autocomplete.js` to confirm there are no remaining `innerHTML` writes for suggestion rendering.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69b413ba2fcc8329891ee4643e0d705b)